### PR TITLE
Use correct LevelDB modules for Node.js and browsers

### DIFF
--- a/Cache.js
+++ b/Cache.js
@@ -1,52 +1,70 @@
 'use strict'
 
 const path = require('path')
-const mkdirp = require('mkdirp')
-const level = require('level')
 
 let caches = {}
 
 class Cache {
-  static async load (directory, dbAddress) {
-    const dbPath = path.join(dbAddress.root, dbAddress.path)
-    const dataPath = path.join(directory, dbPath)
-    let cache = caches[dataPath]
-    if (!cache) {
-      cache = new Cache(dataPath, dbAddress.toString())
-      caches[dataPath] = cache
-      await cache.load()
-    }
-    return cache
-  }
-
-  static async close () {
-    return Promise.all(Object.values(caches), cache => cache.close())
-      .then(() => caches = {})
-  }
-
-  constructor (directory, id) {
+  constructor (storage, directory) {
     this.path = directory || './orbitdb'
-    this.id = id
+    this._storage = storage
     this._store = null
-    this._cache = {}
+  }
+
+  // Setup storage backend
+  async open() {
+    if (this.store)
+      return Promise.resolve()
+
+    return new Promise((resolve, reject) => {
+      const store = this._storage(this.path)
+      store.open((err) => {
+        if (err) {
+          return reject(err)
+        }
+        this._store = store
+        resolve()
+      })
+    })
   }
 
   async close () {
-    if (this._store) 
-      await this._store.close()
+    if (!this._store)
+      return Promise.resolve()
 
-    this._store = null
+    return new Promise(resolve => {
+      this._store.close((err) => {
+        if (err) {
+          return reject(err)
+        }
+        this._store = null
+        delete caches[this.path]
+        resolve()
+      })
+    })
+  }
+
+  async destroy () {
+    return new Promise((resolve, reject) => {
+      this._storage.destroy(this.path, (err) => {
+        if (err) {
+          return reject(err)
+        }
+        resolve()
+      })
+    })
   }
 
   async get(key) {
     if (!this._store)
-      await this.load()
+      await this.open()
 
     return new Promise((resolve, reject) => {
       this._store.get(key, (err, value) => {
         if (err) {
           // Ignore error if key was not found
-          if (err.toString().indexOf('NotFoundError: Key not found in database') === -1)
+          if (err.toString().indexOf('NotFoundError: Key not found in database') === -1
+            && err.toString().indexOf('NotFound') === -1)
             return reject(err)
         }
         resolve(value ? JSON.parse(value) : null)
@@ -57,21 +75,14 @@ class Cache {
   // Set value in the cache and return the new value
   async set(key, value) {
     if (!this._store)
-      await this.load()
-
-    return this._store.put(key, JSON.stringify(value))
-  }
-
-  // Remove a value and key from the cache
-  async del (key) {
-    if (!this._store)
-      await this.load()
+      await this.open()
 
     return new Promise((resolve, reject) => {
-      this._store.del(key, (err, value) => {
+      this._store.put(key, JSON.stringify(value), (err) => {
         if (err) {
           // Ignore error if key was not found
-          if (err.toString().indexOf('NotFoundError: Key not found in database') === -1)
+          if (err.toString().indexOf('NotFoundError: Key not found in database') === -1
+            && err.toString().indexOf('NotFound') === -1)
             return reject(err)
         }
         resolve()
@@ -79,17 +90,43 @@ class Cache {
     })
   }
 
-  // Load cache from a persisted file
-  async load() {
+  // Remove a value and key from the cache
+  async del (key) {
+    if (!this._store)
+      await this.open()
+
     return new Promise((resolve, reject) => {
-      // Check if we have mkdirp
-      if (mkdirp && mkdirp.sync) mkdirp.sync(this.path)
-      level(this.path, (err, db) => {
-        this._store = db
+      this._store.del(key, (err) => {
+        if (err) {
+          // Ignore error if key was not found
+          if (err.toString().indexOf('NotFoundError: Key not found in database') === -1
+            && err.toString().indexOf('NotFound') === -1)
+            return reject(err)
+        }
         resolve()
       })
-     })
+    })
   }
 }
 
-module.exports = Cache
+module.exports = (storage, mkdir) => {
+  return {
+    load: async (directory, dbAddress) => {
+      const dbPath = path.join(dbAddress.root, dbAddress.path)
+      const dataPath = path.join(directory, dbPath)
+      let cache = caches[dataPath]
+      if (!cache) {
+        if (mkdir && mkdir.sync) 
+          mkdir.sync(dataPath)
+        cache = new Cache(storage, dataPath)
+        await cache.open()
+        caches[dataPath] = cache
+      }
+      return cache
+    },
+    close: async () => {
+      await Promise.all(Object.values(caches), cache => cache.close())
+      caches = {}
+    },
+  }
+}

--- a/index-browser.js
+++ b/index-browser.js
@@ -1,0 +1,3 @@
+const level = require('level-js')
+const Cache = require('./Cache')
+module.exports = Cache(level)

--- a/index-nodejs.js
+++ b/index-nodejs.js
@@ -1,0 +1,4 @@
+const level = require('leveldown')
+const mkdirp = require('mkdirp')
+const Cache = require('./Cache')
+module.exports = Cache(level, mkdirp)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,18 @@
   "requires": true,
   "dependencies": {
     "abstract-leveldown": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-3.0.0.tgz",
-      "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+      "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "3.0.0"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+        }
       }
     },
     "ansi-regex": {
@@ -69,28 +76,10 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
-    "deferred-leveldown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-2.0.3.tgz",
-      "integrity": "sha512-8c2Hv+vIwKNc7qqy4zE3t5DIsln+FQnudcyjLYstHwLFg7XnXZT/H8gQb8lj6xi8xqGM0Bz633ZWcCkonycBTA==",
-      "requires": {
-        "abstract-leveldown": "3.0.0"
-      }
-    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-    },
-    "encoding-down": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-3.0.0.tgz",
-      "integrity": "sha1-IGjLZ7E3G14frJtfF44FpVUr+l4=",
-      "requires": {
-        "abstract-leveldown": "3.0.0",
-        "level-codec": "8.0.0",
-        "level-errors": "1.1.1"
-      }
     },
     "end-of-stream": {
       "version": "1.4.0",
@@ -98,14 +87,6 @@
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "requires": {
         "once": "1.4.0"
-      }
-    },
-    "errno": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "requires": {
-        "prr": "0.0.0"
       }
     },
     "expand-template": {
@@ -143,6 +124,11 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
+    "idb-wrapper": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.2.tgz",
+      "integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg=="
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -166,69 +152,55 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "level": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/level/-/level-2.1.0.tgz",
-      "integrity": "sha512-J1MuO0iJuG93xsJjugr2qrAcC95RVKMqrAiio1AcoM2FaAxrUJacAbtfLqYqr7xwQ/NiTXCMfBX71gNmGROXOA==",
-      "requires": {
-        "level-packager": "2.0.2",
-        "leveldown": "2.1.1"
-      }
+    "isbuffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/isbuffer/-/isbuffer-0.0.0.tgz",
+      "integrity": "sha1-OMFG2d9Si4v5sHAcPUPPEt8/w5s="
     },
-    "level-codec": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-8.0.0.tgz",
-      "integrity": "sha512-gNZlo1HRHz0BWxzGCyNf7xntAs2HKOPvvRBWtXsoDvEX4vMYnSTBS6ZnxoaiX7nhxSBPpegRa8CQ/hnfGBKk3Q=="
-    },
-    "level-errors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.1.tgz",
-      "integrity": "sha512-9MIIbizlJgWFQ6m45ehVuSrpzFxwJQmZYD6sfmiizhdmWMNUf41mBYpUJEeCslIa3sB4vdsIFCimPdDZkWznwA==",
+    "level-js": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz",
+      "integrity": "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc=",
       "requires": {
-        "errno": "0.1.4"
-      }
-    },
-    "level-iterator-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.0.tgz",
-      "integrity": "sha512-TWOYw8HR5mhj6xwoVLo0yu26RPL6v28KgvhK1kY1CJf9LyL+rJXjx99zhORTYhN9ysOBIH+iaxAiqRteA+C1/g==",
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
-      }
-    },
-    "level-packager": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-2.0.2.tgz",
-      "integrity": "sha1-AztxFnhELPlWyVFFYnPcY+QXQEc=",
-      "requires": {
-        "encoding-down": "3.0.0",
-        "levelup": "2.0.1"
+        "abstract-leveldown": "0.12.4",
+        "idb-wrapper": "1.7.2",
+        "isbuffer": "0.0.0",
+        "ltgt": "2.2.0",
+        "typedarray-to-buffer": "1.0.4",
+        "xtend": "2.1.2"
       }
     },
     "leveldown": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-2.1.1.tgz",
-      "integrity": "sha512-JNMCTSchq1YtQLMGePmT07UE7hIIYR4GHpZI7+nUXbM9XgNtRAwcBGhnyJyITwpTILTkUcNPBKZ9lZmTUj2E3g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.9.0.tgz",
+      "integrity": "sha512-3MwcrnCUIuFiKp/jSrG1UqDTV4k1yH8f5HH6T9dpqCKG+lRxcfo2KwAqbzTT+TTKfCbaATeHMy9mm1y6sI3ZvA==",
       "requires": {
-        "abstract-leveldown": "3.0.0",
+        "abstract-leveldown": "2.7.2",
         "bindings": "1.3.0",
         "fast-future": "1.0.2",
-        "nan": "2.8.0",
+        "nan": "2.7.0",
         "prebuild-install": "2.4.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "requires": {
+            "xtend": "4.0.1"
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        }
       }
     },
-    "levelup": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.1.tgz",
-      "integrity": "sha1-PckbPmMtN8nlRiOchkEYsATJ+GA=",
-      "requires": {
-        "deferred-leveldown": "2.0.3",
-        "level-errors": "1.1.1",
-        "level-iterator-stream": "2.0.0",
-        "xtend": "4.0.1"
-      }
+    "ltgt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
+      "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
     },
     "minimist": {
       "version": "1.2.0",
@@ -251,9 +223,9 @@
       }
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
     },
     "node-abi": {
       "version": "2.1.2",
@@ -289,6 +261,11 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-keys": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -321,17 +298,19 @@
         "tar-fs": "1.16.0",
         "tunnel-agent": "0.6.0",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        }
       }
     },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-    },
-    "prr": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
     },
     "pump": {
       "version": "1.0.3",
@@ -395,6 +374,13 @@
         "once": "1.4.0",
         "unzip-response": "1.0.2",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        }
       }
     },
     "string-width": {
@@ -448,6 +434,13 @@
         "end-of-stream": "1.4.0",
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        }
       }
     },
     "tunnel-agent": {
@@ -457,6 +450,11 @@
       "requires": {
         "safe-buffer": "5.1.1"
       }
+    },
+    "typedarray-to-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz",
+      "integrity": "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw="
     },
     "unzip-response": {
       "version": "1.0.2",
@@ -482,9 +480,12 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+      "requires": {
+        "object-keys": "0.4.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,14 +2,16 @@
   "name": "orbit-db-cache",
   "version": "0.1.2",
   "description": "Local cache for orbit-db",
-  "main": "Cache.js",
+  "main": "index-nodejs.js",
+  "browser": "index-browser.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Haad",
   "license": "MIT",
   "dependencies": {
-    "level": "^2.1.0",
+    "level-js": "~2.2.4",
+    "leveldown": "^1.9.0",
     "mkdirp": "^0.5.1"
   }
 }


### PR DESCRIPTION
This PR will refactor the Cache to use `leveldown` as the storage backend for Node.js and `level-js` for browsers.