### PR TITLE
Removing handler from cache object

### DIFF
--- a/src/Cache.js
+++ b/src/Cache.js
@@ -7,15 +7,9 @@ Logger.setLogLevel('ERROR')
 class Cache {
   constructor (store) {
     this._store = store
-    this.handlers = new Set()
   }
 
   get status () { return this._store.db.status }
-
-  async removeHandler (address) {
-    if (this.handlers.has(address)) this.handlers.delete(address)
-    if (!this.handlers.size) await this.close()
-  }
 
   async close () {
     if (!this._store) return Promise.reject(new Error('No cache store found to close'))


### PR DESCRIPTION
This PR removes the `handler` management responsibility from Cache, favoring it in OrbitDB