### PR TITLE
Use JSON.stringify

### DIFF
--- a/src/Cache.js
+++ b/src/Cache.js
@@ -53,7 +53,7 @@ class Cache {
             return reject(err)
           }
         }
-        logger.debug(`cache: Set ${key} to ${value}`)
+        logger.debug(`cache: Set ${key} to ${JSON.stringify(value)}`)
         resolve()
       })
     })


### PR DESCRIPTION
The debug log irritatingly has many entries such as 
`cache: cache: Set /orbitdb/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxx/_remoteHeads to [object Object],[object Object]`
This PR fixes the issue by using `JSON.stringify` prior to logging the message
