### PR TITLE
Refactor Cache.js to be more readable by removing Promise and using async functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,13 @@
 version: 2.1
 
 executors:
-  node10-browsers:
+  node-browsers:
     docker:
-      - image: circleci/node:10-browsers
+      - image: cimg/node:16.17-browsers
 
 jobs:
   setup:
-    executor: node10-browsers
+    executor: node-browsers
     steps:
       - checkout
       - run: mkdir -p /tmp/workspace
@@ -25,19 +25,19 @@ jobs:
             - conf
             - package.json
   test-node:
-    executor: node10-browsers
+    executor: node-browsers
     steps:
       - attach_workspace:
           at: ./
       - run: npm run test:node
   test-browser:
-    executor: node10-browsers
+    executor: node-browsers
     steps:
       - attach_workspace:
           at: ./
       - run: npm run test:browser
   build:
-    executor: node10-browsers
+    executor: node-browsers
     steps:
       - attach_workspace:
           at: ./

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-dump.rdb
-orbitdb.json
-node_modules
-redis-stable*
-test/browser/bundle.js*
+orbitdb

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "adam-palazzo",
     "mistakia",
     "RichardLitt",
-    "thiagodelgado111"
+    "thiagodelgado111",
+    "CSDUMMI"
   ],
   "standard": {
     "env": [
@@ -53,7 +54,7 @@
     "memdown": "^6.0.0",
     "mocha": "^8.4.0",
     "mocha-headless-chrome": "^3.1.0",
-    "orbit-db-storage-adapter": "^0.6.0",
+    "orbit-db-storage-adapter": "^0.7.0",
     "orbit-db-test-utils": "^1.0.2",
     "sqlite3": "^5.0.2",
     "standard": "^16.0.3",

--- a/src/Cache.js
+++ b/src/Cache.js
@@ -12,51 +12,34 @@ class Cache {
   get status () { return this._store.db.status }
 
   async close () {
-    if (!this._store) return Promise.reject(new Error('No cache store found to close'))
+    if (!this._store) throw new Error('No cache store found to close')
+
     if (this.status === 'open') {
       await this._store.close()
-      return Promise.resolve()
     }
   }
 
   async open () {
-    if (!this._store) return Promise.reject(new Error('No cache store found to open'))
+    if (!this._store) throw new Error('No cache store found to open')
+
     if (this.status !== 'open') {
       await this._store.open()
-      return Promise.resolve()
     }
   }
 
   async get (key) {
-    return new Promise((resolve, reject) => {
-      this._store.get(key, (err, value) => {
-        if (err) {
-          // Ignore error if key was not found
-          if (err.toString().indexOf('NotFoundError: Key not found in database') === -1 &&
-            err.toString().indexOf('NotFound') === -1) {
-            return reject(err)
-          }
-        }
-        resolve(value ? JSON.parse(value) : null)
-      })
-    })
+    try {
+      return JSON.parse(await this._store.get(key))
+    } catch(e) {
+      if(e.code == 'LEVEL_NOT_FOUND') return null
+      throw e
+    }
   }
 
   // Set value in the cache and return the new value
-  set (key, value) {
-    return new Promise((resolve, reject) => {
-      this._store.put(key, JSON.stringify(value), (err) => {
-        if (err) {
-          // Ignore error if key was not found
-          if (err.toString().indexOf('NotFoundError: Key not found in database') === -1 &&
-            err.toString().indexOf('NotFound') === -1) {
-            return reject(err)
-          }
-        }
-        logger.debug(`cache: Set ${key} to ${JSON.stringify(value)}`)
-        resolve()
-      })
-    })
+  async set (key, value) {
+    await this._store.put(key, JSON.stringify(value))
+    logger.debug(`cache: Set ${key} to ${JSON.stringify(value)}`)
   }
 
   load () {} // noop
@@ -64,18 +47,7 @@ class Cache {
 
   // Remove a value and key from the cache
   async del (key) {
-    return new Promise((resolve, reject) => {
-      this._store.del(key, (err) => {
-        if (err) {
-          // Ignore error if key was not found
-          if (err.toString().indexOf('NotFoundError: Key not found in database') === -1 &&
-            err.toString().indexOf('NotFound') === -1) {
-            return reject(err)
-          }
-        }
-        resolve()
-      })
-    })
+    await this._store.del(key)
   }
 }
 


### PR DESCRIPTION
This PR also handles errors using err.code instead of the string version of the error message in the get() function.